### PR TITLE
Prevent input values in async select from jumping while loading

### DIFF
--- a/scss/control.scss
+++ b/scss/control.scss
@@ -171,8 +171,10 @@
 .Select-loading-zone {
 	cursor: pointer;
 	display: table-cell;
-	position: relative;
+	position: absolute;
+	right: 4px;
 	text-align: center;
+	top: calc(50% - 4px);
 	vertical-align: middle;
 	width: $select-loading-size;
 }


### PR DESCRIPTION
The loading spinner was positioned relatively, which was causing all input values to jump to another line whenever the spinner appeared. 